### PR TITLE
Add support for negative numbers and add testing for it.

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -526,7 +526,7 @@ impl FilterType {
 
 impl ExpectType {
     fn check(&self, val: &str) -> Result<(), String> {
-        let number_filter = Regex::new("[^0-9.,]").unwrap();
+        let number_filter = Regex::new("[^-0-9.,]").unwrap();
 
         match *self {
             ExpectType::Anything => Ok(()),
@@ -565,7 +565,7 @@ impl ExpectType {
                         if compare < *num {
                             Ok(())
                         } else {
-                            Err(format!("The value `{}` not less than `{}`", compare, num))
+                            Err(format!("The value `{}` is not less than `{}`", compare, num))
                         }
                     }
                     Err(_) => Err(format!("Could not parse `{}` as a number", num)),
@@ -578,5 +578,25 @@ impl ExpectType {
 impl Default for ExpectType {
     fn default() -> Self {
         ExpectType::Anything
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expect_negative_numbers() {
+        let expect = ExpectType::LessThan(0.0);
+        assert_eq!(expect.check("-1"), Ok(()));
+        assert_eq!(expect.check("-1.0"), Ok(()));
+        assert_eq!(expect.check("-.01"), Ok(()));
+        assert_eq!(expect.check("-0.01"), Ok(()));
+
+        let expect = ExpectType::GreaterThan(-2.0);
+        assert_eq!(expect.check("-1"), Ok(()));
+        assert_eq!(expect.check("-1.0"), Ok(()));
+        assert_eq!(expect.check("-.01"), Ok(()));
+        assert_eq!(expect.check("-0.01"), Ok(()));
     }
 }


### PR DESCRIPTION
I noticed that negative numbers weren't matching correctly for greater than or less than. You could work around this by using say a jmespath filter and pushing the expression into there, but might as well. There should probably be more tests written, but I shall leave that as an exercise for the reader :).